### PR TITLE
Enhanced covered-call analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# Trading-utils
+# Trading Utils
+
+This repository provides tools for analyzing covered call strategies. Core modules expose calculation utilities while `interactive_dashboard.ipynb` offers an interactive notebook.
+
+## Setup
+
+```bash
+pip install -r requirements.txt  # installs numpy, pandas, matplotlib, ipywidgets, scipy, flake8, black, pytest
+```
+
+## Usage
+
+1. Open `interactive_dashboard.ipynb` in JupyterLab.
+2. Adjust the widgets to explore returns, payoff diagrams, Greeks, Monte-Carlo simulations and more.
+3. Run the notebook cells to update results.
+
+Unit tests can be run with:
+
+```bash
+pytest
+```
+
+Code is formatted with Black and checked with flake8.

--- a/covered_call.py
+++ b/covered_call.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+
 @dataclass
 class CashResult:
     net_investment: float
@@ -7,6 +8,7 @@ class CashResult:
     return_if_unchanged: float
     break_even: float
     downside_protection: float
+
 
 @dataclass
 class MarginResult:
@@ -30,17 +32,11 @@ def calc_cash_returns(
     """Compute covered call returns assuming cash account."""
     premium_total = option_price * shares
     net_investment = (
-        shares * stock_price
-        + comm_stock_buy
-        - premium_total
-        + comm_option_sell
+        shares * stock_price + comm_stock_buy - premium_total + comm_option_sell
     )
 
     profit_exercised = (
-        shares * strike_price
-        - comm_stock_sell
-        + dividends
-        - net_investment
+        shares * strike_price - comm_stock_sell + dividends - net_investment
     )
     return_if_exercised = profit_exercised / net_investment * 100
 
@@ -93,17 +89,11 @@ def calc_margin_returns(
     return_if_exercised = profit_exercised / net_investment * 100
 
     profit_unchanged = (
-        shares * stock_price
-        + dividends
-        - interest
-        - debit_balance
-        - net_investment
+        shares * stock_price + dividends - interest - debit_balance - net_investment
     )
     return_if_unchanged = profit_unchanged / net_investment * 100
 
-    break_even = (
-        net_investment + debit_balance - dividends + interest
-    ) / shares
+    break_even = (net_investment + debit_balance - dividends + interest) / shares
     downside_protection = (stock_price - break_even) / stock_price * 100
 
     return MarginResult(

--- a/covered_call_metrics.py
+++ b/covered_call_metrics.py
@@ -1,0 +1,25 @@
+"""Core metrics for covered call analysis."""
+
+from __future__ import annotations
+
+
+def break_even(
+    stock_price: float,
+    option_premium: float,
+    dividends: float = 0.0,
+    commissions: float = 0.0,
+) -> float:
+    """Return the break-even stock price per share."""
+    return stock_price - option_premium - dividends + commissions
+
+
+def roi(total_profit: float, capital: float, years: float = 1.0) -> tuple[float, float]:
+    """Return total and annualized return on investment (ROI)."""
+    total = total_profit / capital
+    annualized = (1 + total) ** (1 / years) - 1 if years else total
+    return total, annualized
+
+
+def return_on_risk(profit: float, margin_at_risk: float) -> float:
+    """Return profit divided by margin capital at risk."""
+    return profit / margin_at_risk

--- a/interactive_dashboard.ipynb
+++ b/interactive_dashboard.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "34c35f2d",
+   "metadata": {},
+   "source": [
+    "# Enhanced Covered-Call Analyzer\n",
+    "Use the widgets below to explore covered call outcomes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d4b0e38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import ipywidgets as widgets\n",
+    "\n",
+    "from payoff_plot import plot_payoff\n",
+    "from scenario_table import make_scenarios\n",
+    "from option_greeks import call_greeks\n",
+    "from monte_carlo import simulate, stats, plot_hist\n",
+    "from margin_call import margin_call_price\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f089a70f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "shares = widgets.IntSlider(value=100, min=100, max=1000, step=100, description='Shares')\n",
+    "stock = widgets.FloatSlider(value=50.0, min=10, max=100, step=1, description='Stock')\n",
+    "strike = widgets.FloatSlider(value=55.0, min=10, max=100, step=1, description='Strike')\n",
+    "prem = widgets.FloatSlider(value=2.0, min=0.1, max=10, step=0.1, description='Premium')\n",
+    "vol = widgets.FloatSlider(value=0.2, min=0.05, max=1.0, step=0.05, description='Sigma')\n",
+    "mu = widgets.FloatSlider(value=0.1, min=-0.2, max=0.2, step=0.01, description='Mu')\n",
+    "\n",
+    "\n",
+    "def update(_=None):\n",
+    "    prices = np.linspace(stock.value * 0.5, stock.value * 1.5, 50)\n",
+    "    plot_payoff(stock.value, strike.value, prem.value, prices)\n",
+    "    df = make_scenarios([stock.value * 0.8, strike.value, stock.value * 1.2], stock.value, strike.value, prem.value)\n",
+    "    display(df)\n",
+    "    g = call_greeks(stock.value, strike.value, 0.01, vol.value, 0.5)\n",
+    "    display(g)\n",
+    "    sims = simulate(stock.value, mu.value, vol.value, strike.value, prem.value, 0.5, 5000)\n",
+    "    display(stats(sims))\n",
+    "    plot_hist(sims)\n",
+    "\n",
+    "for w in (shares, stock, strike, prem, vol, mu):\n",
+    "    w.observe(update, 'value')\n",
+    "\n",
+    "widgets.VBox([shares, stock, strike, prem, vol, mu])\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/margin_call.py
+++ b/margin_call.py
@@ -1,0 +1,13 @@
+"""Margin call calculator."""
+
+from __future__ import annotations
+
+
+def margin_call_price(
+    stock_price: float, margin_rate: float, maintenance: float
+) -> tuple[float, float]:
+    """Return critical price and drawdown percentage triggering margin call."""
+    debit = stock_price * (1 - margin_rate)
+    critical = debit / (1 - maintenance)
+    drawdown = (stock_price - critical) / stock_price * 100
+    return critical, drawdown

--- a/monte_carlo.py
+++ b/monte_carlo.py
@@ -1,0 +1,44 @@
+"""Monte-Carlo simulator for covered calls."""
+
+from __future__ import annotations
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from payoff_plot import payoff_values
+
+
+def simulate(
+    S0: float,
+    mu: float,
+    sigma: float,
+    strike: float,
+    premium: float,
+    years: float,
+    paths: int,
+) -> np.ndarray:
+    """Simulate terminal P/L paths."""
+    steps = int(252 * years)
+    dt = years / steps
+    prices = np.full(paths, S0)
+    for _ in range(steps):
+        z = np.random.normal(size=paths)
+        prices *= np.exp((mu - 0.5 * sigma**2) * dt + sigma * np.sqrt(dt) * z)
+    pl = payoff_values(S0, strike, premium, prices)
+    return pl
+
+
+def stats(data: np.ndarray) -> dict[str, float]:
+    """Return summary statistics for simulated P/L."""
+    mean = float(np.mean(data))
+    median = float(np.median(data))
+    var = float(np.percentile(data, 5))
+    es = float(data[data <= var].mean())
+    return {"mean": mean, "median": median, "VaR95": var, "ES95": es}
+
+
+def plot_hist(data: np.ndarray, bins: int = 50) -> None:
+    plt.hist(data, bins=bins, color="steelblue", edgecolor="black")
+    plt.xlabel("P/L")
+    plt.ylabel("Frequency")
+    plt.show()

--- a/option_greeks.py
+++ b/option_greeks.py
@@ -1,0 +1,43 @@
+"""Compute Black-Scholes Greeks for a European call."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from scipy.stats import norm
+
+
+@dataclass
+class Greeks:
+    delta: float
+    theta: float
+    gamma: float
+    net_delta: float
+
+
+def _d1(S: float, K: float, r: float, sigma: float, t: float) -> float:
+    return (math.log(S / K) + (r + 0.5 * sigma**2) * t) / (sigma * math.sqrt(t))
+
+
+def _d2(d1: float, sigma: float, t: float) -> float:
+    return d1 - sigma * math.sqrt(t)
+
+
+def call_greeks(
+    S: float, K: float, r: float, sigma: float, t: float, shares: int = 100
+) -> Greeks:
+    """Return option delta, theta, gamma, and net position delta."""
+    d1 = _d1(S, K, r, sigma, t)
+    d2 = _d2(d1, sigma, t)
+    delta = norm.cdf(d1)
+    theta = (
+        -(
+            S * norm.pdf(d1) * sigma / (2 * math.sqrt(t))
+            + r * K * math.exp(-r * t) * norm.cdf(d2)
+        )
+        / 365
+    )
+    gamma = norm.pdf(d1) / (S * sigma * math.sqrt(t))
+    net_delta = shares - delta * shares / 100
+    return Greeks(delta, theta, gamma, net_delta)

--- a/payoff_plot.py
+++ b/payoff_plot.py
@@ -1,0 +1,47 @@
+"""Payoff diagram utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def payoff_values(
+    stock_price: float, strike_price: float, premium: float, prices: np.ndarray
+) -> np.ndarray:
+    """Compute net P/L for a covered call at given terminal prices."""
+    return np.where(
+        prices > strike_price,
+        strike_price - stock_price + premium,
+        prices - stock_price + premium,
+    )
+
+
+def plot_payoff(
+    stock_price: float,
+    strike_price: float,
+    premium: float,
+    prices: np.ndarray | None = None,
+) -> None:
+    """Plot payoff diagram for a covered call."""
+    if prices is None:
+        prices = np.linspace(stock_price * 0.5, stock_price * 1.5, 100)
+    pl = payoff_values(stock_price, strike_price, premium, prices)
+    break_even = stock_price - premium
+    max_gain = strike_price - stock_price + premium
+
+    fig, ax = plt.subplots()
+    ax.plot(prices, pl, label="Covered Call")
+    ax.axhline(0, color="black", linewidth=0.8)
+    ax.axvline(break_even, color="gray", linestyle="--", linewidth=0.8)
+    ax.axhline(max_gain, color="gray", linestyle=":", linewidth=0.8)
+    ax.annotate(
+        "Max Gain", xy=(prices[-1], max_gain), xytext=(0, 5), textcoords="offset points"
+    )
+    ax.annotate(
+        "Break-even", xy=(break_even, 0), xytext=(0, -15), textcoords="offset points"
+    )
+    ax.set_xlabel("Stock Price at Expiration")
+    ax.set_ylabel("Net P/L")
+    ax.legend()
+    plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy
+pandas
+matplotlib
+ipywidgets
+scipy
+flake8
+black
+pytest

--- a/scenario_table.py
+++ b/scenario_table.py
@@ -1,0 +1,24 @@
+"""Scenario table generation."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+
+from payoff_plot import payoff_values
+
+
+def make_scenarios(
+    terminal_prices: Sequence[float],
+    stock_price: float,
+    strike_price: float,
+    premium: float,
+) -> pd.DataFrame:
+    """Return DataFrame comparing covered call and buy-and-hold."""
+    prices = np.array(terminal_prices, dtype=float)
+    cc = payoff_values(stock_price, strike_price, premium, prices)
+    bh = prices - stock_price
+    df = pd.DataFrame({"Terminal Price": prices, "Covered Call": cc, "Buy & Hold": bh})
+    return df

--- a/sensitivity_heatmap.py
+++ b/sensitivity_heatmap.py
@@ -1,0 +1,39 @@
+"""Heatmap utilities for price/time sensitivity."""
+
+from __future__ import annotations
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from payoff_plot import payoff_values
+
+
+def heatmap(
+    stock_price: float,
+    strike_price: float,
+    premium: float,
+    weeks: int,
+    price_range: tuple[float, float] | None = None,
+) -> None:
+    """Plot heatmap of expected P/L over price and time."""
+    if price_range is None:
+        price_range = (stock_price * 0.5, stock_price * 1.5)
+    prices = np.linspace(price_range[0], price_range[1], 50)
+    weeks_arr = np.arange(weeks + 1)
+    pl_matrix = np.zeros((len(weeks_arr), len(prices)))
+    for i, wk in enumerate(weeks_arr):
+        decay = (weeks - wk) / weeks
+        pl_matrix[i] = payoff_values(stock_price, strike_price, premium * decay, prices)
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(
+        pl_matrix,
+        extent=[prices[0], prices[-1], 0, weeks],
+        origin="lower",
+        aspect="auto",
+        cmap="coolwarm",
+    )
+    ax.set_xlabel("Price")
+    ax.set_ylabel("Weeks to Expiration")
+    fig.colorbar(im, ax=ax, label="P/L")
+    plt.show()

--- a/test_metrics_greeks.py
+++ b/test_metrics_greeks.py
@@ -1,0 +1,22 @@
+from covered_call_metrics import break_even, roi, return_on_risk
+from option_greeks import call_greeks
+
+
+def test_break_even():
+    assert break_even(50, 2, dividends=1) == 47
+
+
+def test_roi():
+    total, annual = roi(10, 100, years=1)
+    assert round(total, 2) == 0.10
+    assert round(annual, 2) == 0.10
+
+
+def test_return_on_risk():
+    assert return_on_risk(5, 50) == 0.1
+
+
+def test_call_greeks():
+    g = call_greeks(50, 55, 0.01, 0.2, 0.5)
+    assert round(g.delta, 3) == round(g.delta, 3)  # ensure numeric
+    assert round(g.gamma, 3) > 0


### PR DESCRIPTION
## Summary
- add modular library for covered call metrics and greek calculations
- provide charting helpers, Monte‑Carlo simulator, and margin tools
- new interactive Jupyter notebook dashboard
- update README and requirements
- add tests for metrics and greeks

## Testing
- `flake8 *.py`
- `black *.py`
- `pytest --cov=. -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae2c77ff08325851c1a6749a814d3